### PR TITLE
add direction argument to IPSI transition summaries; correct delta docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: margot
 Type: Package
 Title: MARGinal Observational Treatment-effects
-Version: 1.1.011
+Version: 1.1.012
 Authors@R: person("Joseph A", "Bulbulia", email = "joseph.bulbulia@gmail.com", role = c("aut", "cre"))
 Author: Joseph A Bulbulia [aut, cre]
 Maintainer: Joseph A Bulbulia <joseph.bulbulia@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,26 @@
+# [2026-07-16] margot 1.1.012
+
+### Fixed
+- `margot_compute_ipsi_probability()` and `margot_transition_ipsi_summary()`
+  gain a `direction` argument (`"up"`, the previous behaviour, or `"down"`).
+  The functions were hard-coded to the upward transition (State 0 cohort
+  entering State 1), so support diagnostics for a downward-matched
+  incremental propensity score contingency (raising the probability of the
+  lower state among the upper-state cohort) silently described the opposite
+  intervention. `direction = "down"` reads the State 1 row and the State 0
+  column. `margot_transition_table()$compute_ipsi_probabilities()` passes
+  the argument through.
+- Documentation and report text no longer describe delta as an odds
+  multiplier. The implemented counterfactual `p' = 1 - (1 - p)/delta`
+  matches `lmtp::ipsi()`, the risk-ratio incremental propensity score
+  intervention (with probability `1 - 1/delta` set the exposure to the
+  target state, else keep the natural value); it is not the Kennedy (2019)
+  odds-multiplier IPSI. Registered estimand text should describe the
+  intervention in risk-ratio terms.
+- Result tables carry a `direction` column and direction-neutral count
+  names (`events`, `at_risk`); the legacy `initiations`/`non_attenders`
+  names remain as aliases.
+
 # [2026-07-02] margot 1.1.011
 
 ### Added

--- a/R/margot_compute_ipsi_probability.R
+++ b/R/margot_compute_ipsi_probability.R
@@ -1,27 +1,50 @@
-#' Compute IPSI counterfactual initiation probabilities
+#' Compute IPSI counterfactual transition probabilities
 #'
 #' Takes a formatted transition matrix (for example, one of the formatted tables
 #' produced by `margot_transition_table()` such as
 #' `transition_tables$tables_data[[i]]` or the paired `knitr_kable` stored under
-#' `transition_tables$tables[[i]]`) and computes the natural initiation
-#' probability for baseline non-attenders along with the counterfactual
-#' probabilities implied by marginal incremental propensity score interventions
-#' (IPSIs) for a set of proposed deltas.
+#' `transition_tables$tables[[i]]`) and computes the natural probability of
+#' moving to the target state along with the counterfactual probabilities
+#' implied by incremental propensity score interventions (IPSIs) for a set of
+#' proposed deltas.
+#'
+#' @details
+#' The delta here matches `lmtp::ipsi()`, which implements the risk-ratio
+#' incremental propensity score intervention: with probability \eqn{1 - 1/\delta}
+#' the intervention sets the exposure to the target state, and otherwise leaves
+#' the natural value. The counterfactual probability of the target state is
+#' therefore \eqn{p' = 1 - (1 - p)/\delta}: the natural probability of *not*
+#' reaching the target state is divided by \eqn{\delta}. This is not the
+#' odds-multiplier IPSI of Kennedy (2019), where \eqn{\delta} multiplies the
+#' odds of exposure; describe registered estimands accordingly.
+#'
+#' Direction selects the transition of interest. With `direction = "up"` (the
+#' default, matching earlier versions) the at-risk cohort is the `"State 0"`
+#' row and the event is arrival in `"State 1"` (initiation). With
+#' `direction = "down"` the at-risk cohort is the `"State 1"` row and the event
+#' is arrival in `"State 0"` — the natural reading for a contingency that
+#' raises the probability of the lower state among the upper-state cohort.
 #'
 #' @param trans_matrix A data frame containing at least a `"From / To"` column,
-#'   a `"State 1"` column, and a `"Total"` column. Must include a row identified
-#'   as `"State 0"` under `"From / To"`, representing non-attenders at the prior
-#'   wave. You can pass either the raw data frame or the `knitr_kable` object
+#'   the two state columns (`"State 0"`, `"State 1"`), and a `"Total"` column.
+#'   You can pass either the raw data frame or the `knitr_kable` object
 #'   returned inside `margot_transition_table(... )$tables[[i]]` (the function
 #'   automatically reads the attached `table_data` attribute).
-#' @param deltas Numeric vector of IPSI shift magnitudes (greater than 1). The
-#'   defaults match the standard IPSI reporting set `c(2, 5, 10)`.
+#' @param deltas Numeric vector of IPSI shift magnitudes (greater than 1),
+#'   interpreted as in `lmtp::ipsi()` (risk ratio on the probability of not
+#'   reaching the target state). The defaults match the standard IPSI
+#'   reporting set `c(2, 5, 10)`.
+#' @param direction Either `"up"` (State 0 cohort moving to State 1; the
+#'   default) or `"down"` (State 1 cohort moving to State 0).
 #'
-#' @return A data frame with one row per delta containing the natural initiation
-#'   probability `p`, its exact 95% Clopper-Pearson confidence limits, the
-#'   counterfactual probability `p' = 1 - (1 - p) / delta`, and the fold increase
-#'   `p'/p`. The result carries a `counts` attribute with the raw initiation and
-#'   at-risk totals and the natural-probability interval used to compute `p`.
+#' @return A data frame with one row per delta containing the direction, the
+#'   natural transition probability `p`, its exact 95% Clopper-Pearson
+#'   confidence limits, the counterfactual probability
+#'   `p' = 1 - (1 - p) / delta`, and the fold increase `p'/p`. The result
+#'   carries a `counts` attribute with the raw event and at-risk totals
+#'   (`events`, `at_risk`; the legacy names `initiations` and `non_attenders`
+#'   are kept as aliases) and the natural-probability interval used to compute
+#'   `p`.
 #' @examples
 #' trans <- data.frame(
 #'   `From / To` = c("State 0", "State 1"),
@@ -32,9 +55,13 @@
 #' )
 #' margot_compute_ipsi_probability(trans)
 #' margot_compute_ipsi_probability(trans, deltas = c(1.5, 3))
+#' margot_compute_ipsi_probability(trans, direction = "down")
 #'
 #' @export
-margot_compute_ipsi_probability <- function(trans_matrix, deltas = c(2, 5, 10)) {
+margot_compute_ipsi_probability <- function(trans_matrix,
+                                            deltas = c(2, 5, 10),
+                                            direction = c("up", "down")) {
+  direction <- match.arg(direction)
   if (inherits(trans_matrix, "knitr_kable")) {
     data_attr <- attr(trans_matrix, "table_data")
     if (is.null(data_attr)) {
@@ -46,32 +73,36 @@ margot_compute_ipsi_probability <- function(trans_matrix, deltas = c(2, 5, 10)) 
 
   if (!is.data.frame(trans_matrix)) stop("`trans_matrix` must be a data frame.")
 
-  required_cols <- c("From / To", "State 1", "Total")
+  # the at-risk row is the origin state; the event column is the target state
+  from_state <- if (direction == "up") "State 0" else "State 1"
+  to_state <- if (direction == "up") "State 1" else "State 0"
+
+  required_cols <- c("From / To", to_state, "Total")
   missing_cols <- setdiff(required_cols, colnames(trans_matrix))
   if (length(missing_cols)) {
     stop("`trans_matrix` is missing required columns: ", paste(missing_cols, collapse = ", "))
   }
 
-  rows_state0 <- trans_matrix[trimws(as.character(trans_matrix$`From / To`)) == "State 0", , drop = FALSE]
-  if (!nrow(rows_state0)) stop("No 'State 0' row found in transition matrix.")
+  rows_from <- trans_matrix[trimws(as.character(trans_matrix$`From / To`)) == from_state, , drop = FALSE]
+  if (!nrow(rows_from)) stop("No '", from_state, "' row found in transition matrix.")
 
-  initiations <- sum(as.numeric(rows_state0$`State 1`), na.rm = TRUE)
-  non_attenders <- sum(as.numeric(rows_state0$Total), na.rm = TRUE)
-  if (!is.finite(initiations) || initiations < 0) {
-    stop("Initiation counts (State 1 column) must be non-negative numbers.")
+  events <- sum(as.numeric(rows_from[[to_state]]), na.rm = TRUE)
+  at_risk <- sum(as.numeric(rows_from$Total), na.rm = TRUE)
+  if (!is.finite(events) || events < 0) {
+    stop("Event counts (", to_state, " column) must be non-negative numbers.")
   }
-  if (!is.finite(non_attenders) || non_attenders <= 0) {
-    stop("Total counts for 'State 0' must be positive numbers.")
+  if (!is.finite(at_risk) || at_risk <= 0) {
+    stop("Total counts for '", from_state, "' must be positive numbers.")
   }
-  if (initiations > non_attenders) {
-    warning("Initiation count exceeds Total for 'State 0'; check the transition matrix.")
+  if (events > at_risk) {
+    warning("Event count exceeds Total for '", from_state, "'; check the transition matrix.")
   }
 
-  p <- initiations / non_attenders
-  ci <- stats::binom.test(initiations, non_attenders)$conf.int
-  if (!is.finite(p) || p < 0) stop("Natural initiation probability is not well-defined.")
+  p <- events / at_risk
+  ci <- stats::binom.test(events, at_risk)$conf.int
+  if (!is.finite(p) || p < 0) stop("Natural transition probability is not well-defined.")
   if (p > 1) {
-    warning("Natural initiation probability exceeds 1; resetting to 1 for downstream calculations.")
+    warning("Natural transition probability exceeds 1; resetting to 1 for downstream calculations.")
     p <- 1
   }
 
@@ -79,18 +110,21 @@ margot_compute_ipsi_probability <- function(trans_matrix, deltas = c(2, 5, 10)) 
   if (!length(deltas) || any(!is.finite(deltas))) stop("`deltas` must contain finite numeric values.")
   if (any(deltas <= 1)) stop("All `deltas` must be greater than 1.")
 
+  # lmtp::ipsi() risk-ratio draw: the natural probability of not reaching the
+  # target state is divided by delta
   p_prime <- 1 - (1 - p) / deltas
   # guard against numerical drift outside [0, 1]
   p_prime <- pmin(pmax(p_prime, 0), 1)
 
   fold <- if (p == 0) {
-    warning("Natural initiation probability is zero; fold increase is undefined (set to NA).")
+    warning("Natural transition probability is zero; fold increase is undefined (set to NA).")
     rep(NA_real_, length(deltas))
   } else {
     p_prime / p
   }
 
   result <- data.frame(
+    direction = rep(direction, length(deltas)),
     delta = deltas,
     delta_inverse = round(1 / deltas, 3),
     natural_p = rep(p, length(deltas)),
@@ -101,8 +135,12 @@ margot_compute_ipsi_probability <- function(trans_matrix, deltas = c(2, 5, 10)) 
     stringsAsFactors = FALSE
   )
   attr(result, "counts") <- list(
-    initiations = initiations,
-    non_attenders = non_attenders,
+    direction = direction,
+    events = events,
+    at_risk = at_risk,
+    # legacy aliases retained for backward compatibility
+    initiations = events,
+    non_attenders = at_risk,
     natural_p = p,
     natural_p_l = ci[1],
     natural_p_u = ci[2]

--- a/R/margot_transition_ipsi_summary.R
+++ b/R/margot_transition_ipsi_summary.R
@@ -1,20 +1,31 @@
 #' Summarize IPSI probabilities from transition tables
 #'
 #' Consumes the output of `margot_transition_table()` (or a compatible list of
-#' transition matrices) and computes initiation probabilities for each wave pair
+#' transition matrices) and computes transition probabilities for each wave pair
 #' under incremental propensity score interventions (IPSIs). Internally it calls
 #' `margot_compute_ipsi_probability()` for every matrix, returning a tidy data
-#' frame that includes the natural initiation rate, counterfactual probabilities,
+#' frame that includes the natural transition rate, counterfactual probabilities,
 #' fold increases, and the raw counts used in each estimate.
+#'
+#' The deltas match `lmtp::ipsi()`: the intervention divides the natural
+#' probability of *not* reaching the target state by delta (a risk-ratio
+#' shift), so `p' = 1 - (1 - p)/delta`. Direction selects the transition of
+#' interest: `"up"` summarises movement from State 0 into State 1
+#' (initiation); `"down"` summarises movement from State 1 into State 0 (the
+#' natural reading for a contingency that raises the probability of the lower
+#' state among the upper-state cohort).
 #'
 #' @param transitions Either the object returned by `margot_transition_table()`
 #'   or a list of transition matrices (data frames or `knitr_kable`s containing
-#'   `"From / To"`, `"State 1"`, and `"Total"` columns). When an object from
-#'   `margot_transition_table()` is supplied, the stored wave labels are used in
-#'   the summary.
+#'   `"From / To"`, the state columns, and a `"Total"` column). When an object
+#'   from `margot_transition_table()` is supplied, the stored wave labels are
+#'   used in the summary.
 #' @param deltas Numeric vector of IPSI scaling factors (greater than 1). Passed
 #'   to `margot_compute_ipsi_probability()`; defaults to the standard set
 #'   `c(2, 5, 10)`.
+#' @param direction Either `"up"` (State 0 cohort moving to State 1; the
+#'   default) or `"down"` (State 1 cohort moving to State 0). Passed to
+#'   `margot_compute_ipsi_probability()`.
 #' @param pretty Logical; if `TRUE`, the table component is formatted for
 #'   `knitr::kable()` / `kbl()` while numeric values remain attached under
 #'   `attr(table, "raw")`.
@@ -24,7 +35,7 @@
 #' @return A list with two elements:
 #'   \describe{
 #'     \item{`table`}{Data frame with one row per wave pair × delta containing
-#'       the natural initiation rate (with 95% CI), counterfactual probabilities,
+#'       the natural transition rate (with 95% CI), counterfactual probabilities,
 #'       fold increases, and raw counts (string-formatted when `pretty = TRUE`).}
 #'     \item{`report`}{Character vector of NZ-English sentences, with LaTeX math
 #'       markup (e.g., `$\\to$`, `$\\delta$`, `$p'$`), summarising each wave pair.}
@@ -53,9 +64,11 @@
 #' @export
 margot_transition_ipsi_summary <- function(transitions,
                                            deltas = c(2, 5, 10),
+                                           direction = c("up", "down"),
                                            pretty = FALSE,
                                            digits_prob = 1,
                                            digits_fold = 1) {
+  direction <- match.arg(direction)
   stopifnot(length(deltas) > 0, all(is.finite(deltas)), all(deltas > 1))
   digits_prob <- max(0L, as.integer(digits_prob))
   digits_fold <- max(0L, as.integer(digits_fold))
@@ -103,7 +116,7 @@ margot_transition_ipsi_summary <- function(transitions,
     if (!is.data.frame(mat)) {
       stop("Each transition matrix must be a data frame or knitr_kable with table_data.")
     }
-    probs <- margot_compute_ipsi_probability(mat, deltas = deltas)
+    probs <- margot_compute_ipsi_probability(mat, deltas = deltas, direction = direction)
     counts <- attr(probs, "counts")
     waves <- if (!is.null(waves_list) && length(waves_list) >= i) waves_list[[i]] else c(NA, NA)
     rows[[i]] <- cbind(
@@ -111,8 +124,11 @@ margot_transition_ipsi_summary <- function(transitions,
       table_name = tbl_names[[i]],
       wave_from = waves[1],
       wave_to = waves[2],
-      initiations = counts$initiations,
-      non_attenders = counts$non_attenders,
+      events = counts$events,
+      at_risk = counts$at_risk,
+      # legacy column names retained for backward compatibility
+      initiations = counts$events,
+      non_attenders = counts$at_risk,
       probs,
       stringsAsFactors = FALSE
     )
@@ -150,21 +166,30 @@ margot_transition_ipsi_summary <- function(transitions,
       format_pct_sentence(counts$natural_p_l),
       format_pct_sentence(counts$natural_p_u)
     )
+    transition_phrase <- if (direction == "up") {
+      "moving up (State 0 $\\to$ State 1)"
+    } else {
+      "moving down (State 1 $\\to$ State 0)"
+    }
+    cohort_phrase <- if (direction == "up") "State 0" else "State 1"
     header <- sprintf(
-      "%s: The natural initiation rate was approximately %s (95\\%% CI %s) based on %s initiations out of %s non-attenders.",
+      "%s: The natural rate of %s was approximately %s (95\\%% CI %s) based on %s transitions out of %s at-risk participants in %s.",
       label,
+      transition_phrase,
       format_pct_sentence(counts$natural_p),
       ci_text,
-      format_count(counts$initiations),
-      format_count(counts$non_attenders)
+      format_count(counts$events),
+      format_count(counts$at_risk),
+      cohort_phrase
     )
-    formula_sentence <- "Counterfactual probabilities follow $p' = 1 - (1 - p)/\\delta$ for this transition."
+    formula_sentence <- "Counterfactual probabilities follow $p' = 1 - (1 - p)/\\delta$ for this transition (the risk-ratio incremental propensity score intervention of `lmtp::ipsi()`, which divides the probability of remaining in the natural state by $\\delta$; $\\delta$ is not an odds multiplier)."
     delta_lines <- vapply(
       seq_len(nrow(df)),
       function(j) sprintf(
-        "For $\\delta = %s$ (so $1/\\delta = %s$), the counterfactual initiation probability is about %s (natural $p$ %s; %s).",
+        "For $\\delta = %s$ (so $1/\\delta = %s$), the counterfactual probability of %s is about %s (natural $p$ %s; %s).",
         df$delta[j],
         format_num(df$delta_inverse[j]),
+        transition_phrase,
         format_pct_sentence(df$counterfactual_p[j]),
         format_pct_sentence(df$natural_p[j]),
         format_fold_sentence(df$fold_increase[j])
@@ -195,9 +220,10 @@ margot_transition_ipsi_summary <- function(transitions,
     )
     table_pretty <- data.frame(
       `Wave pair` = wave_pair,
+      Direction = out$direction,
       Delta = out$delta,
       `1/Delta` = out$delta_inverse,
-      `Initiations / at-risk` = sprintf("%s / %s", out$initiations, out$non_attenders),
+      `Transitions / at-risk` = sprintf("%s / %s", out$events, out$at_risk),
       `Natural p (95% CI)` = sprintf(
         "%s (%s, %s)",
         percent_fmt(out$natural_p),

--- a/R/margot_transition_table.R
+++ b/R/margot_transition_table.R
@@ -165,11 +165,13 @@ margot_transition_table <- function(data, state_var, id_var, wave_var,
 
   results$compute_ipsi_probabilities <- function(which = NULL,
                                                  deltas = c(2, 5, 10),
+                                                 direction = c("up", "down"),
                                                  drop = TRUE) {
+    direction <- match.arg(direction)
     idx <- resolve_indices(which, caller = "compute IPSI probabilities")
     out <- lapply(idx, function(i) {
       tbl <- extract_table_data(i)
-      probs <- margot_compute_ipsi_probability(tbl, deltas = deltas)
+      probs <- margot_compute_ipsi_probability(tbl, deltas = deltas, direction = direction)
       list(
         table_index = i,
         waves = results$waves[[i]],

--- a/man/margot_compute_ipsi_probability.Rd
+++ b/man/margot_compute_ipsi_probability.Rd
@@ -2,36 +2,64 @@
 % Please edit documentation in R/margot_compute_ipsi_probability.R
 \name{margot_compute_ipsi_probability}
 \alias{margot_compute_ipsi_probability}
-\title{Compute IPSI counterfactual initiation probabilities}
+\title{Compute IPSI counterfactual transition probabilities}
 \usage{
-margot_compute_ipsi_probability(trans_matrix, deltas = c(2, 5, 10))
+margot_compute_ipsi_probability(
+  trans_matrix,
+  deltas = c(2, 5, 10),
+  direction = c("up", "down")
+)
 }
 \arguments{
 \item{trans_matrix}{A data frame containing at least a `"From / To"` column,
-a `"State 1"` column, and a `"Total"` column. Must include a row identified
-as `"State 0"` under `"From / To"`, representing non-attenders at the prior
-wave. You can pass either the raw data frame or the `knitr_kable` object
+the two state columns (`"State 0"`, `"State 1"`), and a `"Total"` column.
+You can pass either the raw data frame or the `knitr_kable` object
 returned inside `margot_transition_table(... )$tables[[i]]` (the function
 automatically reads the attached `table_data` attribute).}
 
-\item{deltas}{Numeric vector of IPSI shift magnitudes (greater than 1). The
-defaults match the standard IPSI reporting set `c(2, 5, 10)`.}
+\item{deltas}{Numeric vector of IPSI shift magnitudes (greater than 1),
+interpreted as in `lmtp::ipsi()` (risk ratio on the probability of not
+reaching the target state). The defaults match the standard IPSI
+reporting set `c(2, 5, 10)`.}
+
+\item{direction}{Either `"up"` (State 0 cohort moving to State 1; the
+default) or `"down"` (State 1 cohort moving to State 0).}
 }
 \value{
-A data frame with one row per delta containing the natural initiation
-  probability `p`, its exact 95% Clopper-Pearson confidence limits, the
-  counterfactual probability `p' = 1 - (1 - p) / delta`, and the fold increase
-  `p'/p`. The result carries a `counts` attribute with the raw initiation and
-  at-risk totals and the natural-probability interval used to compute `p`.
+A data frame with one row per delta containing the direction, the
+  natural transition probability `p`, its exact 95% Clopper-Pearson
+  confidence limits, the counterfactual probability
+  `p' = 1 - (1 - p) / delta`, and the fold increase `p'/p`. The result
+  carries a `counts` attribute with the raw event and at-risk totals
+  (`events`, `at_risk`; the legacy names `initiations` and `non_attenders`
+  are kept as aliases) and the natural-probability interval used to compute
+  `p`.
 }
 \description{
 Takes a formatted transition matrix (for example, one of the formatted tables
 produced by `margot_transition_table()` such as
 `transition_tables$tables_data[[i]]` or the paired `knitr_kable` stored under
-`transition_tables$tables[[i]]`) and computes the natural initiation
-probability for baseline non-attenders along with the counterfactual
-probabilities implied by marginal incremental propensity score interventions
-(IPSIs) for a set of proposed deltas.
+`transition_tables$tables[[i]]`) and computes the natural probability of
+moving to the target state along with the counterfactual probabilities
+implied by incremental propensity score interventions (IPSIs) for a set of
+proposed deltas.
+}
+\details{
+The delta here matches `lmtp::ipsi()`, which implements the risk-ratio
+incremental propensity score intervention: with probability \eqn{1 - 1/\delta}
+the intervention sets the exposure to the target state, and otherwise leaves
+the natural value. The counterfactual probability of the target state is
+therefore \eqn{p' = 1 - (1 - p)/\delta}: the natural probability of *not*
+reaching the target state is divided by \eqn{\delta}. This is not the
+odds-multiplier IPSI of Kennedy (2019), where \eqn{\delta} multiplies the
+odds of exposure; describe registered estimands accordingly.
+
+Direction selects the transition of interest. With `direction = "up"` (the
+default, matching earlier versions) the at-risk cohort is the `"State 0"`
+row and the event is arrival in `"State 1"` (initiation). With
+`direction = "down"` the at-risk cohort is the `"State 1"` row and the event
+is arrival in `"State 0"` — the natural reading for a contingency that
+raises the probability of the lower state among the upper-state cohort.
 }
 \examples{
 trans <- data.frame(
@@ -43,5 +71,6 @@ trans <- data.frame(
 )
 margot_compute_ipsi_probability(trans)
 margot_compute_ipsi_probability(trans, deltas = c(1.5, 3))
+margot_compute_ipsi_probability(trans, direction = "down")
 
 }

--- a/man/margot_transition_ipsi_summary.Rd
+++ b/man/margot_transition_ipsi_summary.Rd
@@ -7,6 +7,7 @@
 margot_transition_ipsi_summary(
   transitions,
   deltas = c(2, 5, 10),
+  direction = c("up", "down"),
   pretty = FALSE,
   digits_prob = 1,
   digits_fold = 1
@@ -15,13 +16,17 @@ margot_transition_ipsi_summary(
 \arguments{
 \item{transitions}{Either the object returned by `margot_transition_table()`
 or a list of transition matrices (data frames or `knitr_kable`s containing
-`"From / To"`, `"State 1"`, and `"Total"` columns). When an object from
-`margot_transition_table()` is supplied, the stored wave labels are used in
-the summary.}
+`"From / To"`, the state columns, and a `"Total"` column). When an object
+from `margot_transition_table()` is supplied, the stored wave labels are
+used in the summary.}
 
 \item{deltas}{Numeric vector of IPSI scaling factors (greater than 1). Passed
 to `margot_compute_ipsi_probability()`; defaults to the standard set
 `c(2, 5, 10)`.}
+
+\item{direction}{Either `"up"` (State 0 cohort moving to State 1; the
+default) or `"down"` (State 1 cohort moving to State 0). Passed to
+`margot_compute_ipsi_probability()`.}
 
 \item{pretty}{Logical; if `TRUE`, the table component is formatted for
 `knitr::kable()` / `kbl()` while numeric values remain attached under
@@ -35,7 +40,7 @@ to `margot_compute_ipsi_probability()`; defaults to the standard set
 A list with two elements:
   \describe{
     \item{`table`}{Data frame with one row per wave pair × delta containing
-      the natural initiation rate (with 95% CI), counterfactual probabilities,
+      the natural transition rate (with 95% CI), counterfactual probabilities,
       fold increases, and raw counts (string-formatted when `pretty = TRUE`).}
     \item{`report`}{Character vector of NZ-English sentences, with LaTeX math
       markup (e.g., `$\\to$`, `$\\delta$`, `$p'$`), summarising each wave pair.}
@@ -43,11 +48,20 @@ A list with two elements:
 }
 \description{
 Consumes the output of `margot_transition_table()` (or a compatible list of
-transition matrices) and computes initiation probabilities for each wave pair
+transition matrices) and computes transition probabilities for each wave pair
 under incremental propensity score interventions (IPSIs). Internally it calls
 `margot_compute_ipsi_probability()` for every matrix, returning a tidy data
-frame that includes the natural initiation rate, counterfactual probabilities,
+frame that includes the natural transition rate, counterfactual probabilities,
 fold increases, and the raw counts used in each estimate.
+}
+\details{
+The deltas match `lmtp::ipsi()`: the intervention divides the natural
+probability of *not* reaching the target state by delta (a risk-ratio
+shift), so `p' = 1 - (1 - p)/delta`. Direction selects the transition of
+interest: `"up"` summarises movement from State 0 into State 1
+(initiation); `"down"` summarises movement from State 1 into State 0 (the
+natural reading for a contingency that raises the probability of the lower
+state among the upper-state cohort).
 }
 \examples{
 transitions <- margot_transition_table(

--- a/tests/testthat/test-margot_compute_ipsi_probability.R
+++ b/tests/testthat/test-margot_compute_ipsi_probability.R
@@ -66,3 +66,40 @@ test_that("margot_compute_ipsi_probability validates inputs", {
   expect_error(margot_compute_ipsi_probability(good_df, deltas = c(1, 2)),
                "greater than 1")
 })
+
+test_that("margot_compute_ipsi_probability handles the down direction", {
+  trans <- data.frame(
+    `From / To` = c("State 0", "State 1"),
+    `State 0` = c(27380, 330),
+    `State 1` = c(845, 170),
+    Total = c(28225, 500),
+    check.names = FALSE
+  )
+
+  res <- margot_compute_ipsi_probability(trans, deltas = c(2.5, 5), direction = "down")
+
+  # at-risk cohort is the State 1 row; the event is arrival in State 0
+  expect_equal(unique(res$direction), "down")
+  expect_equal(res$natural_p, rep(330 / 500, 2))
+  expect_equal(res$counterfactual_p, 1 - (1 - 330 / 500) / c(2.5, 5))
+
+  counts <- attr(res, "counts")
+  expect_equal(counts$direction, "down")
+  expect_equal(counts$events, 330)
+  expect_equal(counts$at_risk, 500)
+  # legacy aliases mirror the event/at-risk counts
+  expect_equal(counts$initiations, counts$events)
+  expect_equal(counts$non_attenders, counts$at_risk)
+})
+
+test_that("margot_compute_ipsi_probability down direction requires a State 1 row", {
+  trans <- data.frame(
+    `From / To` = "State 0",
+    `State 0` = 10,
+    `State 1` = 2,
+    Total = 12,
+    check.names = FALSE
+  )
+  expect_error(margot_compute_ipsi_probability(trans, direction = "down"),
+               "No 'State 1' row")
+})

--- a/tests/testthat/test-margot_transition_ipsi_summary.R
+++ b/tests/testthat/test-margot_transition_ipsi_summary.R
@@ -84,3 +84,21 @@ test_that("margot_transition_ipsi_summary pretty output formats strings", {
   expect_s3_class(raw, "data.frame")
   expect_equal(raw$delta, 2)
 })
+
+test_that("margot_transition_ipsi_summary threads the down direction", {
+  trans1 <- data.frame(
+    `From / To` = c("State 0", "State 1"),
+    `State 0` = c(10, 4),
+    `State 1` = c(2, 6),
+    Total = c(12, 10),
+    check.names = FALSE
+  )
+  res <- margot_transition_ipsi_summary(list(trans1), deltas = 2, direction = "down")
+  tbl <- res$table
+  expect_equal(unique(tbl$direction), "down")
+  expect_equal(tbl$events, 4)
+  expect_equal(tbl$at_risk, 10)
+  expect_equal(tbl$counterfactual_p, 1 - (1 - 4 / 10) / 2)
+  expect_true(any(grepl("moving down", res$report)))
+  expect_false(any(grepl("odds multiplier increase", res$report)))
+})


### PR DESCRIPTION
## Problem

`margot_compute_ipsi_probability()` and `margot_transition_ipsi_summary()` were hard-coded to the upward transition: the State 0 (non-attender / lower-state) cohort entering State 1. Registered LMTP contingencies that match a failed **downward** policy — raising the probability of the lower state among the baseline upper-state cohort — need the opposite transition, and the summaries silently described the wrong intervention.

The documentation also called delta an odds multiplier. The implemented counterfactual `p' = 1 - (1 - p)/delta` matches `lmtp::ipsi()`, the risk-ratio incremental propensity score intervention (with probability `1 - 1/delta` set the exposure to the target state, else keep the natural value); it is not the Kennedy (2019) odds-multiplier IPSI.

## Changes

- New `direction` argument (`"up"` default, preserving existing behaviour; `"down"` reads the State 1 row and State 0 column) on `margot_compute_ipsi_probability()`, `margot_transition_ipsi_summary()`, and the `compute_ipsi_probabilities()` method of `margot_transition_table()`.
- Docs and generated report text describe delta as the `lmtp::ipsi()` risk-ratio shift, never an odds multiplier.
- Output tables gain a `direction` column and direction-neutral counts (`events`, `at_risk`); legacy `initiations`/`non_attenders` retained as aliases.
- Down-direction consistency: for the upper-state indicator, `lmtp::ipsi(1/delta)` yields a moved-down probability of exactly `1 - (1 - p_down)/delta`, which is what `direction = "down"` computes.
- New tests for the down direction and direction threading; all existing IPSI/transition tests pass unchanged.
- Version 1.1.012 with NEWS entry.

## Tests

`testthat::test_local(filter = "ipsi|transition")`: 62 passing, 0 failures.